### PR TITLE
vortex: refactor: Update icao_wtc function to calculate Wake Turbulen…

### DIFF
--- a/src/adsb/icao.rs
+++ b/src/adsb/icao.rs
@@ -65,8 +65,10 @@ pub fn icao(message: &[u32], df: u32) -> Option<u32> {
 pub fn icao_wtc(vc: &(u32, u32)) -> Option<char> {
     match vc {
         (4, 1) => Some('L'),
-        (4, 2) | (4, 3) => Some('M'),
-        (4, 5) => Some('H'),
+        (4, 2) => Some('S'),
+        (4, 3) => Some('M'),
+        (4, 4) => Some('H'),
+        (4, 5) => Some('J'),
         _ => None,
     }
 }
@@ -100,7 +102,13 @@ mod tests {
 
     #[test]
     fn test_icao_wtc() {
-        let vcs = [((4, 1), 'L'), ((4, 2), 'M'), ((4, 3), 'M'), ((4, 5), 'H')];
+        let vcs = [
+            ((4, 1), 'L'),
+            ((4, 2), 'S'),
+            ((4, 3), 'M'),
+            ((4, 4), 'H'),
+            ((4, 5), 'J'),
+        ];
 
         for (vc, value) in vcs.iter() {
             if let Some(result) = crate::adsb::icao_wtc(vc) {
@@ -111,7 +119,7 @@ mod tests {
 
     #[test]
     fn test_icao_wtc_none() {
-        let vcs = [(4, 0), (4, 4), (4, 6), (4, 7)];
+        let vcs = [(4, 0), (4, 6), (4, 7)];
 
         for vc in vcs.iter() {
             assert_eq!(crate::adsb::icao_wtc(vc), None, "VC: {:?}", vc);

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -266,6 +266,11 @@ impl SimpleDisplay for Plane {
             write!(f, " {:5}", "")?;
         }
         if wide {
+            if let Some(w) = adsb::icao_wtc(&self.category) {
+                write!(f, " {}", w)?;
+            } else {
+                write!(f, "  ")?;
+            }
             write!(f, " {}{}", self.category.0, self.category.1)?;
             if self.last_df != 0 {
                 write!(f, " {:>2}", self.last_df)?;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -109,7 +109,7 @@ fn print_header(wide: bool) {
     ];
 
     let extra_headers = [
-        ("VX", 2),
+        ("W", 1),
         ("DF", 2),
         ("TC", 2),
         ("V", 1),
@@ -166,7 +166,7 @@ fn print_legend(wide: bool) {
     ];
 
     let legend_wide = [
-        ("VX", "Vortex Category"),
+        ("W", "Wake Turbulence Category"),
         ("TC", "Type Code"),
         ("V", "ASD-B Version"),
         ("S", "Surveillance Status"),


### PR DESCRIPTION
…ce Category (WTC) based on VDL Mode 2 Code (VC) to accomodat UK 4,4 Heavy category. ICAO Heavy marked as J (Jumbo) now